### PR TITLE
Add Clipboard Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 pulldown-cmark = "0.9.3"
 clap = "2.33"
+clipboard = "0.5"
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ cargo run --release -- -i example.md -o output.html --theme dark
     ```
     
 *   **Tables**: Enable table formatting in your Markdown.
-    
-    
+
     
     ```console
     cargo run --release -- -i <input-file> -o <output-file> --tables


### PR DESCRIPTION
The clipboard functionality allows users to copy the generated HTML directly to the clipboard using the "--clipboard" or "-c" command-line option.
This commit improves user convenience by providing an option to copy HTML to the clipboard for easy sharing or pasting into other applications. 